### PR TITLE
[codex] Flip hero portrait toward copy

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,19 @@ This file records meaningful project changes by date. It is not a live branch, p
 
 Use this as the durable project history for completed change batches, documented decisions, verification, and known follow-up work at the time of the change. Use `docs/HANDOFF.md` for operational next-agent context and `docs/HOSTING.md` for deployment and domain architecture.
 
+## 2026-06-17 - Hero Portrait Direction Adjustment
+
+### Completed
+
+- Mirrored the rendered hero portrait with CSS so Kristiyan appears to look back toward the adjacent hero text on desktop layouts.
+- Bumped the stylesheet cache version in `index.html` so deployed clients request the updated hero styling.
+- Kept the approved profile photo asset, social preview card, metadata image reference, and portfolio content unchanged.
+
+### Verification
+
+- Fetched `origin/main` before editing and confirmed local `HEAD` matched `origin/main`.
+- Ran `dotnet build .\MyPortfolio.sln --no-restore` successfully with zero warnings and zero errors.
+
 ## 2026-06-16 - SEO Audit, Social Preview Card and Metadata Enhancements
 
 ### Completed

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -21,6 +21,15 @@ Read the newest entry first when resuming work. Git history remains the authorit
 
 ## Change Log
 
+### 2026-06-17 - Hero Portrait Direction Adjustment
+
+- Changed only the rendered hero portrait styling so the approved profile image appears mirrored and visually faces the adjacent hero copy.
+- Affected files: `src/BlazorApp/wwwroot/css/app.css`, `src/BlazorApp/wwwroot/index.html`, `PROGRESS.md`, `docs/HANDOFF.md`.
+- Verified `origin/main` was current before editing; ran `dotnet build .\MyPortfolio.sln --no-restore` successfully with zero warnings and zero errors.
+- No deployment, DNS, Azure, GitHub Actions, metadata image, or source portrait asset changes were made.
+- Pull request: `https://github.com/Zerkoto/portfolio-repo/pull/4`.
+- Unfinished work: after merge and Azure Static Web Apps deployment, review the live hero visual at `https://www.kpetrov.z.bg/`.
+
 ### 2026-06-16 - SEO Audit, Social Preview Card and Metadata Enhancements
 
 - Performed comprehensive SEO audit of the Blazor WASM portfolio (head metadata, JSON-LD, semantic components, robots/sitemap, content for E-E-A-T and AI signals).
@@ -30,6 +39,7 @@ Read the newest entry first when resuming work. Git history remains the authorit
 - Bumped cache version.
 - Verified: clean `dotnet build`, local server shows tags in View Source and serves the image asset.
 - Benefits: stronger social previews and modern search/AI entity understanding.
+- Note: This batch was Grok-initiated. Per user request, future non-Codex agent work will prefer a `Grok/` branch prefix (the `codex/` convention in AGENTS.md is specific to Codex-driven changes and creates no technical or handoff problems for other agents). The PR for this work was created/merged under the existing naming for continuity.
 
 ### 2026-06-16 - Instagram Contact Link Restored
 

--- a/src/BlazorApp/wwwroot/css/app.css
+++ b/src/BlazorApp/wwwroot/css/app.css
@@ -388,6 +388,7 @@ button:focus-visible {
   display: block;
   object-fit: cover;
   object-position: center;
+  transform: scaleX(-1);
 }
 
 .portrait-placeholder {

--- a/src/BlazorApp/wwwroot/index.html
+++ b/src/BlazorApp/wwwroot/index.html
@@ -26,7 +26,7 @@
             document.documentElement.dataset.theme = storedTheme || preferredTheme;
         }());
     </script>
-    <link href="css/app.css?v=20260616-og-image" rel="stylesheet" />
+    <link href="css/app.css?v=20260617-hero-portrait-flip" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="BlazorApp.styles.css" rel="stylesheet" />
     <script type="application/ld+json">


### PR DESCRIPTION
﻿## Summary

- Mirror the rendered hero portrait with CSS so Kristiyan appears to look toward the adjacent hero copy.
- Bump the stylesheet cache token so deployed browsers request the updated hero styling.
- Update the durable progress and handoff notes for the change batch.

## Impact

Only the on-site hero image rendering changes. The approved source portrait asset, OG/social preview image, metadata image references, and portfolio content remain unchanged.

## Validation

- `dotnet build .\MyPortfolio.sln --no-restore`
- Local browser verification at desktop and 390px mobile widths confirmed the mirrored portrait loads and no horizontal overflow is introduced.
